### PR TITLE
Add more cases to credit card bin validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Credit card bin validation to allow only numeric values between 6 and 9 digits.
+
 ## [0.5.0] - 2019-10-02
 
 ### Removed

--- a/messages/en.json
+++ b/messages/en.json
@@ -111,7 +111,7 @@
   "promotions.promotion.elligibility.creditCardBin.label": "Credit card BIN",
   "promotions.promotion.elligibility.creditCardBin.verb.any": "is any of",
   "promotions.promotion.elligibility.creditCardBin.placeholder": "Type a BIN number…",
-  "promotions.promotion.elligibility.creditCardBin.error": "BINs {bins} cannot have less than 6 or more than 9 numeric digits",
+  "promotions.promotion.elligibility.creditCardBin.error": "{binsCount, plural, one {BIN} other {BINs}} {bins} cannot have less than 6 or more than 9 numeric digits",
   "promotions.promotion.elligibility.cartProduct.label": "Product in cart",
   "promotions.promotion.elligibility.cartProduct.verb.brand.any": "belongs to any of these brands",
   "promotions.promotion.elligibility.cartProduct.verb.brand.not.any": "does not belong to any of these brands",

--- a/messages/en.json
+++ b/messages/en.json
@@ -111,7 +111,7 @@
   "promotions.promotion.elligibility.creditCardBin.label": "Credit card BIN",
   "promotions.promotion.elligibility.creditCardBin.verb.any": "is any of",
   "promotions.promotion.elligibility.creditCardBin.placeholder": "Type a BIN number…",
-  "promotions.promotion.elligibility.creditCardBin.error": "BINs {bins} cannot have more than 8 characters",
+  "promotions.promotion.elligibility.creditCardBin.error": "BINs {bins} cannot have less than 6 or more than 9 numeric digits",
   "promotions.promotion.elligibility.cartProduct.label": "Product in cart",
   "promotions.promotion.elligibility.cartProduct.verb.brand.any": "belongs to any of these brands",
   "promotions.promotion.elligibility.cartProduct.verb.brand.not.any": "does not belong to any of these brands",

--- a/messages/es.json
+++ b/messages/es.json
@@ -111,7 +111,7 @@
   "promotions.promotion.elligibility.creditCardBin.label": "BIN de tarjeta de crédito",
   "promotions.promotion.elligibility.creditCardBin.verb.any": "es cualquier entre",
   "promotions.promotion.elligibility.creditCardBin.placeholder": "Número de BIN…",
-  "promotions.promotion.elligibility.creditCardBin.error": "BINs {bins} {binsCount, plural, one {debe} other {deben}} tener como mínimo 6 y máximo 9 dígitos numéricos",
+  "promotions.promotion.elligibility.creditCardBin.error": "{binsCount, plural, one {BIN} other {BINs}} {bins} {binsCount, plural, one {debe} other {deben}} tener como mínimo 6 y máximo 9 dígitos numéricos",
   "promotions.promotion.elligibility.cartProduct.label": "Produto en carrito",
   "promotions.promotion.elligibility.cartProduct.verb.brand.any": "pertenece a alguna de estas marcas",
   "promotions.promotion.elligibility.cartProduct.verb.brand.not.any": "no pertenece a alguna de estas marcas",

--- a/messages/es.json
+++ b/messages/es.json
@@ -111,7 +111,7 @@
   "promotions.promotion.elligibility.creditCardBin.label": "BIN de tarjeta de crédito",
   "promotions.promotion.elligibility.creditCardBin.verb.any": "es cualquier entre",
   "promotions.promotion.elligibility.creditCardBin.placeholder": "Número de BIN…",
-  "promotions.promotion.elligibility.creditCardBin.error": "BINs {bins} debe tener como máximo 8 caracteres",
+  "promotions.promotion.elligibility.creditCardBin.error": "BINs {bins} {binsCount, plural, one {debe} other {deben}} tener como mínimo 6 y máximo 9 dígitos numéricos",
   "promotions.promotion.elligibility.cartProduct.label": "Produto en carrito",
   "promotions.promotion.elligibility.cartProduct.verb.brand.any": "pertenece a alguna de estas marcas",
   "promotions.promotion.elligibility.cartProduct.verb.brand.not.any": "no pertenece a alguna de estas marcas",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -111,7 +111,7 @@
   "promotions.promotion.elligibility.creditCardBin.label": "BIN do cartão de crédito",
   "promotions.promotion.elligibility.creditCardBin.verb.any": "é qualquer um entre",
   "promotions.promotion.elligibility.creditCardBin.placeholder": "Número de BIN…",
-  "promotions.promotion.elligibility.creditCardBin.error": "BIN {bins} não {binsCount, plural, one {pode} other {podem}} ter menos que 6 e mais que 9 dígitos numéricos",
+  "promotions.promotion.elligibility.creditCardBin.error": "{binsCount, plural, one {BIN} other {BINs}} {bins} não {binsCount, plural, one {pode} other {podem}} ter menos que 6 e mais que 9 dígitos numéricos",
   "promotions.promotion.elligibility.cartProduct.label": "Produto no carrinho",
   "promotions.promotion.elligibility.cartProduct.verb.brand.any": "pertence a alguma dessas marcas",
   "promotions.promotion.elligibility.cartProduct.verb.brand.not.any": "não pertence a alguma dessas marcas",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -111,7 +111,7 @@
   "promotions.promotion.elligibility.creditCardBin.label": "BIN do cartão de crédito",
   "promotions.promotion.elligibility.creditCardBin.verb.any": "é qualquer um entre",
   "promotions.promotion.elligibility.creditCardBin.placeholder": "Número de BIN…",
-  "promotions.promotion.elligibility.creditCardBin.error": "BIN {bins} não {binsCount, plural, one {pode} other {podem}} ter mais que 8 caractéres",
+  "promotions.promotion.elligibility.creditCardBin.error": "BIN {bins} não {binsCount, plural, one {pode} other {podem}} ter menos que 6 e mais que 9 dígitos numéricos",
   "promotions.promotion.elligibility.cartProduct.label": "Produto no carrinho",
   "promotions.promotion.elligibility.cartProduct.verb.brand.any": "pertence a alguma dessas marcas",
   "promotions.promotion.elligibility.cartProduct.verb.brand.not.any": "não pertence a alguma dessas marcas",

--- a/react/components/Promotion/EligibilitySection/options/creditCardBin/index.tsx
+++ b/react/components/Promotion/EligibilitySection/options/creditCardBin/index.tsx
@@ -5,6 +5,8 @@ import { SelectObject, SelectObjectProps } from '../../../Conditions/Objects'
 
 import { SelectValue } from '../../../Conditions/Objects/SelectObject'
 
+const BIN_REGEX = /^[0-9]{6,9}$/
+
 interface CreditCardBINSelectProps
   extends SelectObjectProps,
     InjectedIntlProps {
@@ -27,7 +29,7 @@ const CreditCardBINSelect: React.FC<CreditCardBINSelectProps> = ({
       multi
       onChange={(value: CreditCardBINSelectProps['value']) => {
         const errorValues = value.filter(
-          item => typeof item.value === 'string' && item.value.length > 8
+          item => typeof item.value === 'string' && !BIN_REGEX.test(item.value)
         )
         const error =
           errorValues.length > 0


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add more cases to credit card bin validation:
- Numeric only
- Length between 6 and 9

#### What problem is this solving?
Atualmente o promotions permite promoções apenas com BIN de tamanho menor ou igual a 8, além de permitir letras, porém esse valor deveria ser entre 6 e 9 e apenas números, vide link https://dev.elo.com.br/documentacao/tabela-de-bins?lng=pt .

```
Faixa de tamanho (em dígitos) do BIN
#
# Indica quais os tamanhos de BIN estão presentes na tabela, por
# exemplo `{ min: 6, max: 9 }` indica que deve-se conferir os
# prefixos do número do cartão (PAN) de tamanhos 6, 7, 8 e 9.
```

https://app.clubhouse.io/vtex/story/23339/add-credit-card-bin-validation

#### How should this be manually tested?
https://binvalidation--pricingqa.myvtex.com/admin/promotions/new/

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/5971264/66062294-8501b180-e517-11e9-882f-309276a72c85.png)
