### PR TITLE
Replace all priceTables with priceTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- discountType should be `priceTable` instead of `priceTables`.
+
 ## [0.8.0] - 2019-10-31
 
 ### Changed

--- a/messages/context.json
+++ b/messages/context.json
@@ -38,7 +38,7 @@
   "promotions.promotion.effects.priceForm.discountType.title": "promotions.promotion.effects.priceForm.discountType.title",
   "promotions.promotion.effects.priceForm.discountType.nominal": "promotions.promotion.effects.priceForm.discountType.nominal",
   "promotions.promotion.effects.priceForm.discountType.percentual": "promotions.promotion.effects.priceForm.discountType.percentual",
-  "promotions.promotion.effects.priceForm.discountType.priceTables": "promotions.promotion.effects.priceForm.discountType.priceTables",
+  "promotions.promotion.effects.priceForm.discountType.priceTable": "promotions.promotion.effects.priceForm.discountType.priceTable",
   "promotions.promotion.effects.priceForm.appliesTo.title": "promotions.promotion.effects.priceForm.appliesTo.title",
   "promotions.promotion.effects.priceForm.appliesTo.all": "promotions.promotion.effects.priceForm.appliesTo.all",
   "promotions.promotion.effects.priceForm.appliesTo.specific": "promotions.promotion.effects.priceForm.appliesTo.specific",

--- a/messages/en.json
+++ b/messages/en.json
@@ -37,7 +37,7 @@
   "promotions.promotion.effects.priceForm.discountType.title": "Discount type",
   "promotions.promotion.effects.priceForm.discountType.nominal": "Nominal",
   "promotions.promotion.effects.priceForm.discountType.percentual": "Percentual",
-  "promotions.promotion.effects.priceForm.discountType.priceTables": "Price tables",
+  "promotions.promotion.effects.priceForm.discountType.priceTable": "Price table",
   "promotions.promotion.effects.priceForm.appliesTo.title": "Affected items",
   "promotions.promotion.effects.priceForm.appliesTo.all": "All Catalog",
   "promotions.promotion.effects.priceForm.appliesTo.specific": "Specific products",

--- a/messages/es.json
+++ b/messages/es.json
@@ -38,7 +38,7 @@
   "promotions.promotion.effects.priceForm.discountType.title": "Tipo de descuento",
   "promotions.promotion.effects.priceForm.discountType.nominal": "Nominal",
   "promotions.promotion.effects.priceForm.discountType.percentual": "Porcentaje",
-  "promotions.promotion.effects.priceForm.discountType.priceTables": "Tabelas de precio",
+  "promotions.promotion.effects.priceForm.discountType.priceTable": "Tabela de precio",
   "promotions.promotion.effects.priceForm.appliesTo.title": "Ítems afectados",
   "promotions.promotion.effects.priceForm.appliesTo.all": "Todo el catálogo",
   "promotions.promotion.effects.priceForm.appliesTo.specific": "Productos específicos",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -38,7 +38,7 @@
   "promotions.promotion.effects.priceForm.discountType.title": "Tipo de desconto",
   "promotions.promotion.effects.priceForm.discountType.nominal": "Nominal",
   "promotions.promotion.effects.priceForm.discountType.percentual": "Percentual",
-  "promotions.promotion.effects.priceForm.discountType.priceTables": "Price tables",
+  "promotions.promotion.effects.priceForm.discountType.priceTable": "Tabela de preços",
   "promotions.promotion.effects.priceForm.appliesTo.title": "Itens afetados",
   "promotions.promotion.effects.priceForm.appliesTo.all": "Todo o catálogo",
   "promotions.promotion.effects.priceForm.appliesTo.specific": "Produtos específicos",

--- a/react/components/Promotion/EffectsSection/PriceForm/index.js
+++ b/react/components/Promotion/EffectsSection/PriceForm/index.js
@@ -199,16 +199,16 @@ class PriceForm extends Component {
             </div>
           ) : null}
           <Radio
-            id="promotions.promotion.effects.priceForm.discountType.priceTables"
+            id="promotions.promotion.effects.priceForm.discountType.priceTable"
             name="price-tables-discount-type"
-            checked={this.isDiscountTypeSelected('priceTables')}
+            checked={this.isDiscountTypeSelected('priceTable')}
             label={intl.formatMessage({
               id:
-                'promotions.promotion.effects.priceForm.discountType.priceTables',
+                'promotions.promotion.effects.priceForm.discountType.priceTable',
             })}
-            onChange={() => this.changeDiscountType('priceTables')}
+            onChange={() => this.changeDiscountType('priceTable')}
           />
-          {this.isDiscountTypeSelected('priceTables') ? (
+          {this.isDiscountTypeSelected('priceTable') ? (
             <div className="mv4 mh7 w-20">
               <Input
                 value={priceEffect.discount.value}


### PR DESCRIPTION
#### What is the purpose of this pull request?

 - updates front to use `priceTable` in singular just like the graphql expects

#### What problem is this solving?

 - price-table-promotions are broken due to `discountType` expected is `priceTable` instead of `priceTables`

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
