### PR TITLE
Fix spanish translations

### DIFF
--- a/messages/es.json
+++ b/messages/es.json
@@ -143,7 +143,7 @@
   "promotions.promotion.cancel": "Cancelar",
   "promotions.promotions.title": "Promotions",
   "promotions.promotions.search": "Buscar",
-  "promotions.promotions.newPromotion": "Nova promoción",
+  "promotions.promotions.newPromotion": "Nueva promoción",
   "promotions.promotions.newPromotion.regular": "Regular",
   "promotions.promotions.newPromotion.combo": "Compre Junto",
   "promotions.promotions.newPromotion.forThePriceOf": "Más por Menos",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix Spanish translation of new promotions button (`Nova promoción -> Nueva Promoción`)

#### What problem is this solving?
[[ch27192](https://app.clubhouse.io/vtex/story/27192/fix-new-promotions-button-spanish-translation)] The new beta version has a translation mistake, it should be "Nueva Promoción" on the button https://prnt.sc/q30m9p.

@juan.etcheverry's team have a Tier 1 demo in arg tomorrow an he claims that this sort of stuff kind of generates the "broken window" effect.

#### How should this be manually tested?
n/a

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/5971264/69759611-4ff19400-1141-11ea-9295-a0553999331a.png)

